### PR TITLE
use the manet dial args in order to figure out the listener

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -21,8 +21,12 @@ type Listener struct {
 }
 
 func newListener(config *connConfig) (*Listener, error) {
+	lnet, lnaddr, err := manet.DialArgs(config.maAddr)
+	if err != nil {
+		return nil, err
+	}
 
-	ln, err := net.Listen(config.addr.Network(), config.addr.String())
+	ln, err := net.Listen(lnet, lnaddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
If you take a look at https://github.com/multiformats/go-multiaddr-net/blob/master/net.go#L271-L291 it does some manipulation on the Dial args before giving them directly to net.Listen .

I noticed this bug because I was using a /ip4/0.0.0.0/0 style address and it was coming back as ip6 and then getting dropped as a maddr on linux. Switching to these args lets me actually use that 0 style addresses.